### PR TITLE
docs: Add comprehensive READMEs for all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# kairos-framework
+# Kairos Framework
+
+The Kairos Framework is a comprehensive, modular platform for building sophisticated, AI-powered applications. It is designed from the ground up to support the entire lifecycle of a modern AI system, from data acquisition and processing to intelligent agentic reasoning and interaction. Built on a robust foundation of Java, Spring Boot, and LangChain4j, Kairos provides a scalable and extensible architecture for creating enterprise-ready AI solutions.
+
+The mission of the Kairos Framework is to provide a cohesive ecosystem of components that abstract away the complexities of building AI systems, allowing developers to focus on creating value and delivering intelligent user experiences. It emphasizes modularity, security, and responsible AI development through its unique architectural design.
+
+## Architectural Overview
+
+The Kairos Framework is composed of several specialized, loosely-coupled modules that work together to form a complete AI pipeline. The architecture is designed to be both scalable and flexible, allowing developers to use the entire framework or select only the components they need.
+
+The typical data and interaction flow through the framework is as follows:
+
+1.  **Data Acquisition (`kairos-crawler`):** The process begins with the `kairos-crawler` module, which actively seeks out and gathers raw content from external sources like websites and YouTube. This raw data is then published to a message queue.
+
+2.  **Ingestion and Processing (`kairos-ingestion`):** The `kairos-ingestion` module consumes the raw content from the message queue. It uses Apache Tika to parse various document formats, splits the content into smaller, meaningful chunks, and prepares it for embedding. The original files are stored using the `kairos-storage` service.
+
+3.  **Embedding and Indexing (`kairos-ai-abstraction` & `kairos-vector-search`):** The text chunks are sent to the `kairos-ai-abstraction` module, which converts them into vector embeddings using a configured large language model (e.g., Google Vertex AI). These embeddings, along with their associated metadata, are then indexed and stored in a PostgreSQL database with the pgvector extension by the `kairos-vector-search` module.
+
+4.  **Agentic Interaction (`kairos-agentic-framework`):** A user interacts with an AI agent created by the `kairos-agentic-framework`. When a user asks a question, the agent uses the `kairos-vector-search` module to perform a semantic search over the indexed knowledge base to find relevant information (Retrieval-Augmented Generation - RAG).
+
+5.  **Responsible AI (`kairos-are-core`):** For advanced use cases, the framework can employ the Axiom-Driven Reasoning Engine (ARE). Before presenting a final response, the agent's proposed answer is sent to the `kairos-are-core` module, where a `ConstitutionalGuardian` agent verifies it against a set of core ethical axioms to ensure it is safe, fair, and reliable.
+
+6.  **Core Services (`kairos-core`, `kairos-notification`, `kairos-storage`):** Throughout this entire process, foundational modules provide essential services. `kairos-core` handles security, data persistence, and shared utilities. `kairos-notification` provides a way to send alerts or messages, and `kairos-storage` manages interactions with object storage.
+
+## Modules
+
+The framework is divided into the following key modules:
+
+### Core Infrastructure
+-   **`kairos-core`**: The foundational layer providing shared entities (JPA), security (Spring Security, JWT), and common utilities for the entire platform.
+-   **`kairos-storage`**: An abstraction layer for object storage, with an initial implementation for Google Cloud Storage. It handles the persistence of raw files.
+-   **`kairos-notification`**: A lightweight service for abstracting and sending notifications, such as emails or SMS.
+
+### Data Pipeline
+-   **`kairos-crawler`**: A content acquisition module that crawls websites (using crawler4j) and other sources like YouTube to gather data for the framework.
+-   **`kairos-ingestion`**: A powerful ingestion pipeline that processes raw content. It uses Apache Tika for parsing, splits documents into chunks, and orchestrates the embedding and indexing process.
+-   **`kairos-vector-search`**: The heart of the framework's knowledge retrieval capabilities. It manages the storage and semantic searching of vector embeddings using PostgreSQL and the pgvector extension.
+
+### AI & Agentic Logic
+-   **`kairos-ai-abstraction`**: A crucial abstraction layer that decouples the framework from specific AI providers. It provides interfaces for chat models, embedding models, and other AI services, with an initial implementation for Google Vertex AI.
+-   **`kairos-agentic-framework`**: The core module for building and managing AI agents. It uses LangChain4j to create tool-augmented, conversational agents with stateful memory.
+-   **`kairos-are-core`**: The Axiom-Driven Reasoning Engine (ARE). This module provides a unique verification layer, ensuring that AI agent behavior aligns with a predefined set of ethical principles.
+
+This modular architecture makes the Kairos Framework a powerful and adaptable choice for building the next generation of intelligent applications.

--- a/kairos-agentic-framework/README.md
+++ b/kairos-agentic-framework/README.md
@@ -1,0 +1,34 @@
+# KAIROS - Agentic Framework
+
+The `kairos-agentic-framework` module provides the core components for building and managing conversational AI agents within the Kairos ecosystem. It is designed to be a flexible and extensible framework that leverages the power of large language models (LLMs) to create intelligent, tool-augmented agents.
+
+## Key Features
+
+- **Agent Abstraction:** Defines a simple and clean `AiAgent` interface that standardizes how the application interacts with conversational agents, decoupling the core application logic from the underlying AI implementation.
+- **Agent Factory:** Provides a powerful `AgentFactory` that simplifies the creation of `AiAgent` instances. The factory automatically discovers and injects all available `@KairosTool` beans from the Spring application context, making it easy to extend the agent's capabilities.
+- **Memory Management:** Each agent instance is provisioned with its own chat memory, ensuring that conversations are stateful and context-aware. It uses a sliding window memory (`MessageWindowChatMemory`) to manage conversational history efficiently.
+- **System Prompts:** Allows for the creation of specialized agents with custom personas and instructions by providing system prompts during agent creation.
+- **Advanced Agent Architectures (Experimental):** Includes an experimental implementation of a multi-agent system, the **Axiom-Driven Reasoning Engine (ARE)**. This advanced architecture features an `AxiomDrivenExecutiveAgent` that orchestrates a council of specialized agents, including an `InvestigativeAgent` and a `GuardianAgent`, to ensure that responses are not only accurate but also aligned with a core set of ethical axioms.
+
+## Core Components
+
+- **`AiAgent`:** The central interface for all conversational agents.
+- **`AgentFactory`:** A Spring service responsible for assembling and configuring `AiAgent` instances with the necessary dependencies, such as the chat model, tools, and memory.
+- **`@KairosTool`:** A custom annotation used to mark any Spring bean as a tool that can be used by an AI agent.
+- **`AxiomDrivenExecutiveAgent`:** An experimental agent that demonstrates a sophisticated multi-agent approach to reasoning and response generation, ensuring safety and alignment with predefined principles.
+
+## Dependencies
+
+This module relies on several other modules within the Kairos Framework:
+
+- **`kairos-core`:** For core application utilities and data structures.
+- **`kairos-ai-abstraction`:** To provide the underlying `ChatLanguageModel` for interacting with the LLM.
+- **`kairos-vector-search`:** For enabling agents to perform semantic searches over a knowledge base.
+- **`kairos-are-core`:** When the Axiom-Driven Reasoning Engine is enabled, this module provides the `GuardianAgent` and the constitutional principles for response verification.
+
+It also integrates with the following key external libraries:
+
+- **LangChain4j:** For its core AI service abstractions, tool handling, and memory management.
+- **Spring Boot:** For dependency injection, component scanning, and overall application configuration.
+
+This module serves as the brain of the Kairos Framework, orchestrating the various components to deliver intelligent and reliable AI-driven interactions.

--- a/kairos-ai-abstraction/README.md
+++ b/kairos-ai-abstraction/README.md
@@ -1,0 +1,27 @@
+# KAIROS - AI Abstraction
+
+The `kairos-ai-abstraction` module serves as a crucial layer in the Kairos Framework, responsible for abstracting all interactions with external AI providers. Its primary goal is to decouple the core application logic from the specific implementations of AI models, allowing for greater flexibility and easier integration with different vendors.
+
+## Key Features
+
+- **Provider Agnosticism:** By defining a set of common interfaces for various AI services (e.g., chat, embedding, transcription), this module allows the rest of the application to remain agnostic about the underlying AI provider. Currently, it provides a concrete implementation for **Google Vertex AI**.
+- **Seamless LangChain4j Integration:** The service interfaces in this module, such as `ChatLanguageModel`, are designed to extend the core interfaces from the **LangChain4j** library. This clever design choice allows Kairos's custom AI services to be used interchangeably within the LangChain4j ecosystem, enabling seamless integration with components like `AiServices`.
+- **Type-Safe Configuration:** It provides a robust and type-safe configuration mechanism through the `VertexAiProperties` class, which centralizes all connection and model-specific settings for Google Vertex AI. This ensures that all required properties are validated at startup.
+- **Conditional Activation:** The entire AI configuration is conditionally activated based on the presence of a `project-id` in the application properties. This allows the application to run without an active AI backend for development or testing purposes.
+- **Extensible Service Layer:** The module is organized into a clean `service` package containing interfaces for various AI functionalities (`ChatLanguageModel`, `EmbeddingModel`, `AudioTranscriptionService`, etc.) and an `impl` package for their concrete implementations. This makes it straightforward to add new AI providers in the future.
+
+## Core Components
+
+- **`ChatLanguageModel`:** The primary interface for interacting with a chat-based large language model. It extends `dev.langchain4j.model.chat.ChatModel`.
+- **`VertexAiGeminiChatModelImpl`:** The concrete implementation of `ChatLanguageModel`, configured to work with Google's Gemini models via Vertex AI.
+- **`VertexAiProperties`:** A `@ConfigurationProperties` class that holds all the necessary settings for connecting to Google Vertex AI, such as project ID, location, model names, and generation parameters.
+- **`KairosAiConfiguration`:** The main Spring configuration class that enables the type-safe properties and scans for service implementations.
+
+## Dependencies
+
+This module integrates with the following key libraries:
+
+- **LangChain4j:** For its core AI model interfaces and the specific `langchain4j-vertex-ai` and `langchain4j-vertex-ai-gemini` integrations.
+- **Spring Boot:** For dependency injection, configuration management, and conditional bean loading.
+
+By providing this abstraction layer, the `kairos-ai-abstraction` module ensures that the Kairos Framework remains adaptable to the rapidly evolving landscape of AI providers and models.

--- a/kairos-are-core/README.md
+++ b/kairos-are-core/README.md
@@ -1,0 +1,29 @@
+# KAIROS - Axiom-Driven Reasoning Engine (ARE) Core
+
+The `kairos-are-core` module is a specialized and critical component of the Kairos Framework, providing the **Axiomatic Verification Layer** for AI agents. Its primary responsibility is to ensure that the behavior of AI agents remains aligned with a predefined set of ethical principles or "axioms." This module is the cornerstone of the experimental **Axiom-Driven Reasoning Engine (ARE)**, a multi-agent architecture designed to produce more reliable, safe, and grounded responses.
+
+## Key Features
+
+- **Constitutional AI:** Implements a form of "Constitutional AI," where an agent's proposed actions or statements are checked against a core constitution before being finalized. This serves as a powerful safety and alignment mechanism.
+- **Axiomatic Set:** Defines a clear and explicit set of principles (`AxiomService`) that govern the agent's behavior. These axioms cover critical areas such as user safety, inclusivity, privacy, and the verifiability of information.
+- **Guardian Agent:** Features a specialized, non-conversational AI agent known as the `ConstitutionalGuardian`. This agent's sole purpose is to receive a proposition from another AI and judge whether it contradicts, is corroborated by, or is neutral with respect to the defined axioms.
+- **Separation of Concerns:** The verification logic is cleanly separated from the primary conversational agent. This allows the main agent to focus on being helpful and creative, while the `ConstitutionalGuardian` handles the critical task of verification.
+- **Enum-Based Judgments:** The `ConstitutionalGuardian` provides its judgment as a strongly-typed `ContradictionStatus` enum (`CONTRADICTS_AXIOM`, `CORROBORATED_BY_AXIOM`, `AXIOM_IS_SILENT`), which makes the verification result easy to handle programmatically and reduces ambiguity.
+
+## Core Components
+
+- **`AxiomService`:** A service that loads and provides the set of core axioms. In the current implementation, these are hardcoded, but they could be loaded from a formal specification file (e.g., YAML) in a production environment.
+- **`ConstitutionalGuardian`:** A specialized agent that uses a highly specific system prompt to evaluate a given proposition against the full constitution provided by the `AxiomService`. It is the workhorse of the verification layer.
+- **`ContradictionStatus`:** An enum that represents the possible outcomes of the verification process.
+
+## How It Works
+
+When the Axiom-Driven Reasoning Engine is active, the `AxiomDrivenExecutiveAgent` (from the `kairos-agentic-framework`) first delegates a user's request to an `InvestigativeAgent` to find a provisional answer. This provisional answer is then passed to the `ConstitutionalGuardian` within this module. The Guardian evaluates the answer against the axioms and returns its judgment. If the answer is found to be in violation of an axiom, the executive agent can then formulate a safe, alternative response.
+
+## Dependencies
+
+- **`kairos-ai-abstraction`:** To provide the `ChatLanguageModel` necessary for the `ConstitutionalGuardian` to perform its verification task.
+- **LangChain4j:** For the `AiServices` builder used to create the internal `VerifierAgent`.
+- **Spring Boot:** For dependency injection.
+
+This module is a key differentiator of the Kairos Framework, providing a sophisticated mechanism for building more responsible and aligned AI systems.

--- a/kairos-core/README.md
+++ b/kairos-core/README.md
@@ -1,0 +1,29 @@
+# KAIROS - Core
+
+The `kairos-core` module is the foundational layer of the Kairos Framework. It provides the essential building blocks, including common data models (entities), security configurations, and shared utilities that are used by nearly every other module in the system. Its primary purpose is to establish a stable and consistent base for the entire platform.
+
+## Key Features
+
+- **Data Persistence:** Establishes the core data persistence layer using **Spring Data JPA**. It defines the fundamental `BaseEntity` from which other data models in the framework inherit, ensuring consistency with ID generation and auditing fields.
+- **Security Foundation:** Implements the application's security foundation using **Spring Security**. It includes support for stateless, token-based authentication using **JSON Web Tokens (JWT)**, which is essential for securing APIs in a distributed environment.
+- **Shared Entities:** Contains the core business entities that are shared across different modules, such as `User` and `Role`. This centralization prevents code duplication and ensures a single source of truth for the main data models.
+- **Repository Layer:** Defines the Spring Data JPA repositories for the core entities (e.g., `UserRepository`), providing a clean and standardized way to interact with the database.
+- **Web and Configuration:** Includes `spring-boot-starter-web` to provide foundational web capabilities and serves as a central point for cross-cutting concerns and configurations.
+
+## Core Components
+
+- **Entities (`/entity`):** Contains the core JPA entities like `User`, `Role`, and `BaseEntity`. These entities define the primary database schema for the application.
+- **Repositories (`/repository`):** Contains the Spring Data JPA repository interfaces for accessing the core entities (e.g., `UserRepository`).
+- **Security (`/security`):** This package houses the security configuration, including the `JwtTokenProvider` for creating and validating JWTs, and the main `SecurityConfig` class that sets up firewall rules, authentication providers, and session management policies.
+- **Configuration (`/config`):** Provides central configuration beans and settings that are applicable across the entire application.
+
+## Dependencies
+
+This module serves as a dependency for almost all other `kairos-*` modules, providing them with the necessary security, data, and utility classes. It integrates with several key external libraries:
+
+- **Spring Boot:** For Data JPA, Security, and Web functionalities.
+- **Hibernate:** As the underlying JPA provider.
+- **JJWT (Java JWT):** For implementing JWT-based authentication.
+- **Lombok:** To reduce boilerplate code in entities and other data objects.
+
+By providing these fundamental services, the `kairos-core` module ensures that the entire Kairos Framework is built on a robust, secure, and maintainable foundation.

--- a/kairos-crawler/README.md
+++ b/kairos-crawler/README.md
@@ -1,0 +1,30 @@
+# KAIROS - Crawler
+
+The `kairos-crawler` module is responsible for actively gathering content from various external sources to be processed and indexed by the Kairos Framework. It acts as the primary data acquisition component, feeding the `kairos-ingestion` pipeline with a steady stream of information from the web, APIs, and other sources.
+
+## Key Features
+
+- **Web Crawling:** Utilizes the **crawler4j** library to efficiently crawl websites, extract their content, and identify links for further exploration. This is ideal for building a knowledge base from public web pages.
+- **YouTube Integration:** Integrates with the **Google YouTube Data API** to fetch video information, such as transcripts and metadata. This allows the framework to ingest content from video sources.
+- **Asynchronous Processing:** Leverages **Spring AMQP (RabbitMQ)** to publish crawled content to a message queue. This decouples the crawling process from the ingestion process, creating a resilient and scalable architecture. The crawler can continue its work without waiting for the ingestion and embedding steps to be completed.
+- **Data Persistence:** Uses Spring Data JPA to interact with the database, likely to keep track of crawled URLs, job status, and other metadata to avoid redundant work and manage the crawling process.
+
+## Core Components
+
+- **Crawlers:** The module contains specific crawler implementations for different data sources (e.g., a `WebCrawler` using crawler4j, a `YouTubeCrawler` using the Google API).
+- **Message Publisher:** A component responsible for sending the raw content gathered by the crawlers to a RabbitMQ exchange. The `kairos-ingestion` module will be the consumer of these messages.
+- **Configuration:** Contains the necessary configuration for connecting to external services like the YouTube API and for setting up the RabbitMQ connection.
+
+## How It Works
+
+A crawl job is initiated, either through a scheduled task, an API call, or a manual trigger. The appropriate crawler (e.g., web or YouTube) begins its work, fetching raw content (HTML, text, video metadata). Once a piece of content is successfully retrieved, the crawler passes it to a message publisher, which sends it to a dedicated RabbitMQ queue. From there, the `kairos-ingestion` module picks it up for parsing, chunking, and embedding.
+
+## Dependencies
+
+- **`kairos-core`:** For access to core data models and utilities.
+- **crawler4j:** The core web crawling library.
+- **google-api-services-youtube:** For interacting with the YouTube Data API.
+- **Spring Boot AMQP:** For integrating with RabbitMQ.
+- **Spring Data JPA:** For database interactions.
+
+This module is essential for populating the Kairos Framework with rich, diverse content, which is the foundation for any knowledge-based AI application.

--- a/kairos-ingestion/README.md
+++ b/kairos-ingestion/README.md
@@ -1,0 +1,42 @@
+# KAIROS - Ingestion Framework
+
+The `kairos-ingestion` module provides a robust and extensible framework for building data ingestion pipelines. Its primary role is to take raw content from various sources—such as documents uploaded via an API or messages from the `kairos-crawler`—and process it into a structured format suitable for storage and vector-based searching.
+
+## Key Features
+
+- **Document Parsing:** Leverages **Apache Tika** to parse a wide variety of document formats, including PDF, Microsoft Office documents (DOCX, PPTX), and more. This allows the framework to extract clean, textual content from complex files.
+- **Content Processing Pipeline:** Implements a flexible pipeline for processing raw data. This typically includes steps such as:
+    1.  **Parsing:** Extracting text from the source file.
+    2.  **Chunking:** Splitting the extracted text into smaller, semantically meaningful segments.
+    3.  **Embedding:** Converting the text chunks into vector embeddings using a model from the `kairos-ai-abstraction` module.
+    4.  **Indexing:** Storing the embeddings and their associated metadata in a vector database via the `kairos-vector-search` module.
+- **Asynchronous Operations:** Designed to handle ingestion tasks asynchronously. It can consume messages from a RabbitMQ queue (populated by the `kairos-crawler`) or handle file uploads from a web endpoint, processing them in the background without blocking the user.
+- **Integration with Core Services:** Tightly integrated with other Kairos modules to perform its functions. It relies on `kairos-storage` to handle raw file persistence, `kairos-ai-abstraction` to generate embeddings, and `kairos-vector-search` to index the final data.
+
+## Core Components
+
+- **Ingestion Service:** The main service that orchestrates the ingestion pipeline. It takes a source (e.g., a `MultipartFile` or a message payload) and manages its journey from raw data to indexed vector embeddings.
+- **Document Parsers:** A set of components, primarily using Apache Tika, that are responsible for extracting text and metadata from different file types.
+- **Text Splitters/Chunkers:** Logic for dividing long documents into smaller chunks. This is a critical step for effective vector-based retrieval, as it ensures that the embeddings represent focused, semantically coherent pieces of information.
+
+## How It Works
+
+The ingestion process can be triggered in several ways, such as a user uploading a file through a REST API endpoint or a message arriving from the `kairos-crawler`.
+
+1.  The raw file or content is received by the `IngestionService`.
+2.  If it's a file, it is first saved to a persistent storage location using the `kairos-storage` module.
+3.  The file's content is extracted using the appropriate Apache Tika parser.
+4.  The extracted text is split into smaller chunks.
+5.  Each chunk is sent to the `kairos-ai-abstraction` module to be converted into a vector embedding.
+6.  The text chunk, its embedding, and any relevant metadata are then passed to the `kairos-vector-search` module to be indexed in the vector database.
+
+## Dependencies
+
+- **`kairos-core`:** For core entities and utilities.
+- **`kairos-vector-search`:** To index the generated embeddings and metadata.
+- **`kairos-storage`:** To store the original raw files.
+- **`kairos-ai-abstraction`:** To access the embedding models needed to create vector representations of the text.
+- **Apache Tika:** The primary library for parsing document content.
+- **Spring Boot:** For building the application and managing asynchronous tasks.
+
+This module acts as the bridge between raw data and searchable knowledge, making it a cornerstone of the Kairos Framework's ability to build intelligent, context-aware AI applications.

--- a/kairos-notification/README.md
+++ b/kairos-notification/README.md
@@ -1,0 +1,28 @@
+# KAIROS - Notification Service
+
+The `kairos-notification` module provides a lightweight and abstracted service for sending notifications within the Kairos Framework. Its purpose is to decouple the core application logic from the specific details of how notifications (such as emails, SMS, or push notifications) are sent.
+
+## Key Features
+
+- **Abstraction:** Defines a simple `NotificationService` interface that can be used throughout the application to send messages without needing to know the underlying delivery mechanism. This makes it easy to swap out notification providers in the future.
+- **Extensibility:** The architecture is designed to be easily extensible. While the initial implementation might support a specific provider (e.g., an email service), new providers can be added by simply creating new implementations of the `NotificationService` interface.
+- **Decoupling:** By centralizing notification logic in this module, other services (like `kairos-agentic-framework` or `kairos-core`) can simply inject the `NotificationService` and use it, adhering to the single-responsibility principle.
+
+## Core Components
+
+- **`NotificationService`:** The primary interface for sending notifications. It will typically define methods like `send(recipient, message)` or more specific versions like `sendEmail(to, subject, body)`.
+- **Implementations:** Concrete implementations of the `NotificationService` interface for specific providers (e.g., `SmtpEmailNotificationService`, `TwilioSmsNotificationService`). These implementations would contain the provider-specific logic and configuration.
+
+## How It Works
+
+Any service within the Kairos Framework that needs to send a notification can inject the `NotificationService` bean. When its `send` method is called, the Spring framework will provide the configured implementation, which then handles the communication with the external notification provider.
+
+For example, a user management service in `kairos-core` could use the `NotificationService` to send a welcome email when a new user signs up.
+
+## Dependencies
+
+- **`kairos-core`:** For access to core entities like `User`, which may contain recipient information (e.g., an email address).
+- **Spring Framework:** For dependency injection and component management.
+- **External Provider SDKs (as needed):** Depending on the implementation, this module would include dependencies for specific notification providers (e.g., `spring-boot-starter-mail` for SMTP, or a third-party SDK for a service like Twilio).
+
+This module provides a simple yet powerful way to manage all outbound notifications, contributing to a clean and maintainable architecture for the Kairos Framework.

--- a/kairos-storage/README.md
+++ b/kairos-storage/README.md
@@ -1,0 +1,29 @@
+# KAIROS - Storage Service
+
+The `kairos-storage` module is responsible for abstracting interactions with cloud-based object storage providers. Its primary purpose is to provide a simple and consistent interface for uploading, downloading, and managing files, decoupling the rest of the Kairos Framework from the specifics of the underlying storage technology.
+
+## Key Features
+
+- **Storage Abstraction:** Defines a clean `StorageService` interface that hides the implementation details of the storage provider. This allows other modules, such as `kairos-ingestion`, to store and retrieve files without being coupled to a specific vendor like Google Cloud Storage or Amazon S3.
+- **Provider-Specific Implementation:** Includes a concrete implementation for **Google Cloud Storage (GCS)**, leveraging the `google-cloud-storage` SDK to handle the actual communication with the GCS API.
+- **Extensibility:** The architecture makes it straightforward to add support for other storage providers in the future. To add support for AWS S3, for example, one would simply need to create a new `S3StorageServiceImpl` that implements the `StorageService` interface.
+- **Centralized Configuration:** The configuration required to connect to the storage provider (e.g., bucket names, credentials) is managed within this module, providing a single point of control for storage settings.
+
+## Core Components
+
+- **`StorageService`:** The main interface that defines the core file operations, such as `save(file)`, `load(fileName)`, and `delete(fileName)`.
+- **`GoogleCloudStorageServiceImpl`:** The concrete implementation of `StorageService` that uses the Google Cloud Storage client library to perform file operations on GCS.
+- **Configuration Beans:** Spring configuration classes that are responsible for instantiating the `Storage` client from the Google Cloud SDK, using credentials and project information provided in the application's properties.
+
+## How It Works
+
+When a module like `kairos-ingestion` receives a file to be processed, it first calls the `save` method of the `StorageService`. The `StorageService` implementation then takes care of uploading the file to the configured object storage bucket (e.g., in GCS) and returns a unique identifier or path for the stored file. This identifier can then be used to retrieve the file later if needed.
+
+## Dependencies
+
+- **`kairos-core`:** For any shared utilities or configuration that might be required.
+- **`google-cloud-storage`:** The Google Cloud SDK for Java, used to interact with Google Cloud Storage.
+- **Spring Boot:** For dependency injection and configuration management.
+- **Lombok:** To reduce boilerplate code.
+
+By abstracting away the details of file storage, the `kairos-storage` module helps to create a more portable and maintainable system, allowing the framework to adapt to different cloud environments with minimal code changes.

--- a/kairos-vector-search/README.md
+++ b/kairos-vector-search/README.md
@@ -1,0 +1,34 @@
+# KAIROS - Vector & Search
+
+The `kairos-vector-search` module is a sophisticated component of the Kairos Framework responsible for indexing, storing, and querying vector embeddings and their associated metadata. This module provides the core functionality for semantic search, enabling AI agents to find relevant information from a large knowledge base based on meaning rather than just keywords.
+
+## Key Features
+
+- **Vector Database Integration:** Provides a robust integration with **PostgreSQL** using the **pgvector** extension. This allows for efficient storage and similarity searching of high-dimensional vector embeddings directly within the database.
+- **LangChain4j Integration:** Leverages the **LangChain4j** library for seamless integration with vector stores. It uses LangChain4j's `EmbeddingStore` abstraction and provides a concrete implementation based on `PgVectorEmbeddingStore`, which handles the complexities of interacting with the pgvector extension.
+- **Combined Storage:** This module is designed to store both the vector embeddings and the original text content (or metadata) together. This is crucial for retrieval-augmented generation (RAG), as it allows the system to retrieve the relevant text chunks that correspond to the vector search results.
+- **Flexible Indexing:** Offers a flexible service layer that allows for the indexing of documents with rich metadata. This enables more advanced search scenarios, such as filtering by source, date, or other attributes.
+- **Search Abstraction:** Defines a `VectorSearchService` that abstracts the details of the querying process. This allows other modules, like `kairos-agentic-framework`, to perform semantic searches without needing to know the specifics of the underlying vector database implementation.
+
+## Core Components
+
+- **`VectorSearchService`:** The primary service for interacting with the vector database. It provides methods for indexing new documents (`index(document)`) and searching for relevant documents based on a query embedding (`search(queryEmbedding, topK)`).
+- **`PgVectorEmbeddingStore`:** The core component from LangChain4j that is configured and used to manage the lifecycle of embeddings within the PostgreSQL database.
+- **Entity Definitions:** Contains the JPA entity definitions for the tables that store the embeddings and their associated metadata. This defines the schema for the vector store.
+- **Configuration:** Provides the necessary Spring configuration to set up the `DataSource` and the `PgVectorEmbeddingStore`, connecting it to the PostgreSQL database and configuring parameters like the vector dimensions.
+
+## How It Works
+
+1.  **Indexing:** The `kairos-ingestion` module processes a document, splits it into chunks, and generates a vector embedding for each chunk. It then calls the `index` method of the `VectorSearchService` in this module, passing the text chunk, its embedding, and any metadata. The service then persists this information in the pgvector-enabled database.
+2.  **Searching:** An AI agent in the `kairos-agentic-framework` needs to answer a user's question. It first generates an embedding for the user's query. It then calls the `search` method of the `VectorSearchService`, providing the query embedding. The service uses pgvector's similarity search capabilities (e.g., cosine similarity) to find the most relevant document chunks from the database and returns them to the agent. The agent then uses this retrieved information to formulate its response.
+
+## Dependencies
+
+- **`kairos-core`:** For core utilities and base entity classes.
+- **`kairos-ai-abstraction`:** To access the embedding models when generating embeddings for queries.
+- **`langchain4j-pgvector`:** The key LangChain4j integration library for pgvector.
+- **`pgvector` (JDBC wrapper):** The JDBC driver that adds support for the `vector` data type.
+- **PostgreSQL Driver:** The standard JDBC driver for PostgreSQL.
+- **Spring Boot:** For Data JPA, JDBC, and overall application management.
+
+This module is the heart of the framework's knowledge retrieval capabilities, transforming a simple database into a powerful engine for semantic understanding and search.


### PR DESCRIPTION
This commit introduces comprehensive documentation for the entire Kairos Framework.

A detailed `README.md` file has been created for each of the nine modules, outlining their specific purpose, key features, core components, and dependencies.

Additionally, the main project `README.md` has been completely rewritten to provide a high-level architectural overview, explain the end-to-end data and interaction flow, and summarize the role of each module within the ecosystem.

This documentation significantly improves the project's usability and maintainability by providing a clear and thorough explanation of its structure and functionality.